### PR TITLE
 Include arument type infomation in option class, closes issue #3

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -277,7 +277,7 @@ class Command(Argument):
 
 
 class Option(LeafPattern):
-    def __init__(self, short: Optional[str] = None, longer: Optional[str] = None, argcount: int = 0, value: Union[List[str], str, int, None] = False, atype: Optional[str] = None)  -> None:
+    def __init__(self, short: Optional[str] = None, longer: Optional[str] = None, argcount: int = 0, value: Union[List[str], str, int, None] = False, atype: Optional[str] = None) -> None:
         assert argcount in (0, 1)
         self.short, self.longer, self.argcount, self.atype = short, longer, argcount, atype
         self.value = None if value is False and argcount else value

--- a/docopt.py
+++ b/docopt.py
@@ -18,7 +18,8 @@ Contributors (roughly in chronological order):
  * Copyright (c) 2015 Benjamin Bach <benjaoming@gmail.com>
  * Copyright (c) 2017 Oleg Bulkin <o.bulkin@gmail.com>
  * Copyright (c) 2018 Iain Barnett <iainspeed@gmail.com>
- * Copyright (c) 2019 itdaniher, itdaniher@gmail.com
+ * Copyright (c) 2019 itdaniher, <itdaniher@gmail.com>
+ * Copyright (c) 2019 con-f-use, <con-f-use@gmx.net>
 
 """
 
@@ -276,14 +277,14 @@ class Command(Argument):
 
 
 class Option(LeafPattern):
-    def __init__(self, short: Optional[str] = None, longer: Optional[str] = None, argcount: int = 0, value: Union[List[str], str, int, None] = False) -> None:
+    def __init__(self, short: Optional[str] = None, longer: Optional[str] = None, argcount: int = 0, value: Union[List[str], str, int, None] = False, atype: Optional[str] = None)  -> None:
         assert argcount in (0, 1)
-        self.short, self.longer, self.argcount = short, longer, argcount
+        self.short, self.longer, self.argcount, self.atype = short, longer, argcount, atype
         self.value = None if value is False and argcount else value
 
     @classmethod
     def parse(class_, option_description: str) -> "Option":
-        short, longer, argcount, value = None, None, 0, False
+        short, longer, argcount, value, atype = None, None, 0, False, None
         options, _, description = option_description.strip().partition("  ")
         options = options.replace(",", " ").replace("=", " ")
         for s in options.split():
@@ -291,12 +292,15 @@ class Option(LeafPattern):
                 longer = s
             elif s.startswith("-"):
                 short = s
+            elif s:
+                atype = s
+                argcount = 1
             else:
                 argcount = 1
         if argcount:
             matched = re.findall(r"\[default: (.*)\]", description, flags=re.I)
             value = matched[0] if matched else None
-        return class_(short, longer, argcount, value)
+        return class_(short, longer, argcount, value, atype)
 
     def single_match(self, left: List[LeafPattern]) -> TSingleMatch:
         for n, pattern in enumerate(left):
@@ -309,7 +313,7 @@ class Option(LeafPattern):
         return self.longer or self.short
 
     def __repr__(self) -> str:
-        return "Option(%r, %r, %r, %r)" % (self.short, self.longer, self.argcount, self.value)
+        return "Option(%r, %r, %r, %r, %r)" % (self.short, self.longer, self.argcount, self.value, self.atype)
 
 
 class Required(BranchPattern):

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -33,23 +33,23 @@ def test_option():
     assert Option.parse("-h --help") == Option("-h", "--help")
     assert Option.parse("-h, --help") == Option("-h", "--help")
 
-    assert Option.parse("-h TOPIC") == Option("-h", None, 1)
-    assert Option.parse("--help TOPIC") == Option(None, "--help", 1)
-    assert Option.parse("-h TOPIC --help TOPIC") == Option("-h", "--help", 1)
-    assert Option.parse("-h TOPIC, --help TOPIC") == Option("-h", "--help", 1)
-    assert Option.parse("-h TOPIC, --help=TOPIC") == Option("-h", "--help", 1)
+    assert Option.parse("-h TOPIC") == Option("-h", None, 1, None, "TOPIC")
+    assert Option.parse("--help TOPIC") == Option(None, "--help", 1, None, "TOPIC")
+    assert Option.parse("-h TOPIC --help TOPIC") == Option("-h", "--help", 1, None, "TOPIC")
+    assert Option.parse("-h TOPIC, --help TOPIC") == Option("-h", "--help", 1, None, "TOPIC")
+    assert Option.parse("-h TOPIC, --help=TOPIC") == Option("-h", "--help", 1, None, "TOPIC")
 
     assert Option.parse("-h  Description...") == Option("-h", None)
     assert Option.parse("-h --help  Description...") == Option("-h", "--help")
-    assert Option.parse("-h TOPIC  Description...") == Option("-h", None, 1)
+    assert Option.parse("-h TOPIC  Description...") == Option("-h", None, 1, None, "TOPIC")
 
     assert Option.parse("    -h") == Option("-h", None)
 
-    assert Option.parse("-h TOPIC  Descripton... [default: 2]") == Option("-h", None, 1, "2")
-    assert Option.parse("-h TOPIC  Descripton... [default: topic-1]") == Option("-h", None, 1, "topic-1")
-    assert Option.parse("--help=TOPIC  ... [default: 3.14]") == Option(None, "--help", 1, "3.14")
-    assert Option.parse("-h, --help=DIR  ... [default: ./]") == Option("-h", "--help", 1, "./")
-    assert Option.parse("-h TOPIC  Descripton... [dEfAuLt: 2]") == Option("-h", None, 1, "2")
+    assert Option.parse("-h TOPIC  Descripton... [default: 2]") == Option("-h", None, 1, "2", "TOPIC")
+    assert Option.parse("-h TOPIC  Descripton... [default: topic-1]") == Option("-h", None, 1, "topic-1", "TOPIC")
+    assert Option.parse("--help=TOPIC  ... [default: 3.14]") == Option(None, "--help", 1, "3.14", "TOPIC")
+    assert Option.parse("-h, --help=DIR  ... [default: ./]") == Option("-h", "--help", 1, "./", "DIR")
+    assert Option.parse("-h TOPIC  Descripton... [dEfAuLt: 2]") == Option("-h", None, 1, "2", "TOPIC")
 
 
 def test_option_name():
@@ -498,4 +498,4 @@ def test_parse_section():
 
 def test_issue_126_defaults_not_parsed_correctly_when_tabs():
     section = "Options:\n\t--foo=<arg>  [default: bar]"
-    assert parse_defaults(section) == [Option(None, "--foo", 1, "bar")]
+    assert parse_defaults(section) == [Option(None, "--foo", 1, "bar", "<arg>")]


### PR DESCRIPTION
This PR makes argument validation easier by parsing argument types and making them accessible, if provided in the docstring.

E.g. merging this Pull request makes this possible:

```python
"""Some stuff

Usage:
    {__package__} [options]

Options:
    -s --speed=<float>    Speed in km/h [default: 42]
    --count=<posint>      How often [default: 1]

"""
__doc__ = __doc__.format(**globals())


from docopt import docopt, parse_defaults


def convert_arg(atype, value):
    if atype == '<float>':
        return float(value)
    elif atype == '<posint>':
        value = int(value)
        if value < 0:
            raise ValueError('Must be positive integer!')
        return value
    return value


if __name__ == '__main__':
    args = docopt(__doc__, version="Dei mama hat a version!")
    atypes = {(o.longer or o.short):o.atype for o in parse_defaults(__doc__)}

    for key, value in args.items():
        if key in atypes:
            args[key] = convert_arg(atypes[key], value)

    print(args)
```
In action:
```
┌─11-18:15[con-f-use@confusion6:~/devel/docopt-ng] $ 
└▪ python playground.py
{'--count': 1,
    '--speed': 42.0}
┌─11-18:16[con-f-use@confusion6:~/devel/docopt-ng] $ 
└▪ python playground.py --count -1
Traceback (most recent call last):
    File "playground.py", line 35, in <module>
    args[key] = convert_arg(atypes[key], value)
    File "playground.py", line 24, in convert_arg
    raise ValueError('Must be positive integer!')
ValueError: Must be positive integer!
```
Note how `--count` and `--speed` are actual number types as opposed to strings.

see: https://github.com/bazaar-projects/docopt-ng/issues/3