### PR TITLE
Cleaning state pollution of global variable `arguments` by assigning with None

### DIFF
--- a/tests/test_docopt_ng.py
+++ b/tests/test_docopt_ng.py
@@ -104,6 +104,7 @@ def test_docopt_ng_more_magic_global_arguments_and_dot_access():
 
     with raises(DocoptExit):
         docopt.docopt(doc, "--fake")
+    arguments = None
 
 
 def test_docopt_ng__doc__if_no_doc():


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_docopt_ng_more_magic_global_arguments_and_dot_access` by cleaning state pollution of global variable `arguments` by assigning with None.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_docopt_ng.py::test_docopt_ng_more_magic_global_arguments_and_dot_access`:

```
        global arguments
        docopt.docopt(doc, "-v file.py", more_magic=True)
>       assert arguments == {"-v": True, "-q": False, "-r": False, "--help": False, "FILE": "file.py", "INPUT": None, "OUTPUT": None}
E       AssertionError: assert {'--help': Fa...OUTPUT': None} == {'--help': Fa...v': True, ...}
E         Omitting 6 identical items, use -vv to show
E         Left contains 1 more item:
E         {'<FILE>': None}
E         Right contains 1 more item:
E         {'FILE': 'file.py'}
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
