### PR TITLE
Report exceptions that cause failures in testcases.docopt

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ class DocoptTestItem(pytest.Item):
                     f"expect> {json.dumps(self.expect)}",
                 )
             )
+        return super().repr_failure(excinfo)
 
     def reportinfo(self):
         return self.path, 0, f"usecase: {self.name}"


### PR DESCRIPTION
Currently only `DocoptTestException` is reported, no info on the error is shown if any other error is raised during a `testcases.docopt` test. This change delegates to the default `pytest.Item` error reporting implementation for non-docopt errors.