### PR TITLE
Restore compatibility with docopt 0.6.2 docstrings

### DIFF
--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -948,7 +948,10 @@ def docopt(
     sections = parse_docstring_sections(docstring)
     lint_docstring(sections)
     DocoptExit.usage = sections.usage_header + sections.usage_body
-    options = parse_options(sections.after_usage)
+    options = [
+        *parse_options(sections.before_usage),
+        *parse_options(sections.after_usage),
+    ]
     pattern = parse_pattern(formal_usage(sections.usage_body), options)
     pattern_options = set(pattern.flat(Option))
     for options_shortcut in pattern.flat(OptionsShortcut):

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -726,8 +726,8 @@ def parse_docstring_sections(docstring: str) -> DocSections:
     following the usage section.
     """
     usage_pattern = r"""
-    # Any number of lines precede the usage section
-    \A(?P<before_usage>(?:.*\n)*?)
+    # Any number of lines (that don't include usage:) precede the usage section
+    \A(?P<before_usage>(?:(?!.*\busage:).*\n)*)
     # The `usage:` section header.
     ^(?P<usage_header>.*usage:)
     (?P<usage_body>

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -303,7 +303,9 @@ class Option(LeafPattern):
     @classmethod
     def parse(class_, option_description: str) -> Option:
         short, longer, argcount, value = None, None, 0, False
-        options, _, description = option_description.strip().partition("  ")
+        options, description = re.split(
+            r"(?:  )|$", option_description.strip(), flags=re.M, maxsplit=1
+        )
         options = options.replace(",", " ").replace("=", " ")
         for s in options.split():
             if s.startswith("--"):

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -729,7 +729,7 @@ def parse_docstring_sections(docstring: str) -> DocSections:
     # Any number of lines (that don't include usage:) precede the usage section
     \A(?P<before_usage>(?:(?!.*\busage:).*\n)*)
     # The `usage:` section header.
-    ^(?P<usage_header>.*usage:)
+    ^(?P<usage_header>.*\busage:)
     (?P<usage_body>
         # The first line of the body may follow the header without a line break:
         (?:

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -775,7 +775,7 @@ def parse_options(docstring: str) -> list[Option]:
     option_start = r"""
     # Option descriptions begin on a new line
     ^
-    # They may be occur on the same line as an options: section heading
+    # They may occur on the same line as an options: section heading
     (?:.*options:)?
     # They can be indented with whitespace
     [ \t]*

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -780,7 +780,7 @@ def parse_options(docstring: str) -> list[Option]:
     # They can be indented with whitespace
     [ \t]*
     # The description itself starts with the short or long flag (-x or --xxx)
-    (-\S+?)
+    (-\S)
     """
     parts = re.split(option_start, docstring, flags=re.M | re.I | re.VERBOSE)[1:]
     return [

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -801,6 +801,11 @@ def lint_docstring(sections: DocSections):
             'Failed to parse docstring: More than one "usage:" '
             "(case-insensitive) section found."
         )
+    if sections.usage_body.strip() == "":
+        raise DocoptLanguageError(
+            'Failed to parse docstring: "usage:" section is empty.'
+            "Check http://docopt.org/ for examples of how your doc should look."
+        )
 
 
 def formal_usage(usage: str) -> str:

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -732,12 +732,7 @@ def parse_docstring_sections(docstring: str) -> DocSections:
     ^(?P<usage_header>.*\busage:)
     (?P<usage_body>
         # The first line of the body may follow the header without a line break:
-        (?:
-            # Some non-whitespace content
-            [ \t]*\S.*(?:\n|\Z)
-            # Or after a newline, followed by indentation
-            |(?:[ \t]*\n[ \t].*(?:\n|\Z))
-        )
+        (?:.*(?:\n|\Z))
         # Any number of additional indented lines
         (?:[ \t].*(?:\n|\Z))*
     )

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -827,6 +827,41 @@ option_examples: Sequence[tuple[str, Sequence[Option]]] = [
             Option("-e", None, 0, False),
         ],
     ),
+    # Option-like things which aren't actually options
+    (
+        """
+        --option1 <x>  This really is an option.
+                       And it has a default [default: 42]
+
+        Talking about options:
+            Here we're talking about options and defaults, like [default: 3] and
+            options such as --foo, but we're not intending to define them. And
+            although the default of 3 I just mentioned does not get picked up as
+            the default of --option1, defined above.
+
+            But if we happen to start a line of our prose with an option, like
+            -b then we are unfortunately defining an option. And "then" acts as
+            an argument for -b, so it accepts an argument.
+
+            Options are also allowed to start on the same line as an option
+            heading, so this is an option:
+            options: --option2
+
+            And this also works after several words, so options: --option3  is
+            also an option. But options after other heading-like things aren't
+            picked up, so this isn't an option:
+            things: --not-an-option
+
+        -o, --option4 <x>  This is also a real option
+        """,
+        [
+            Option(None, "--option1", 1, "42"),
+            Option("-b", None, 1, None),
+            Option(None, "--option2", 0, False),
+            Option(None, "--option3", 0, False),
+            Option("-o", "--option4", 1, None),
+        ],
+    ),
 ]
 option_examples = [(dedent(doc), options) for (doc, options) in option_examples]
 

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -943,6 +943,24 @@ def test_parse_docstring_sections__reports_invalid_docstrings(invalid_docstring:
             "(case-insensitive) section found.",
             id="multiple_usage_sections",
         ),
+        pytest.param(
+            """\
+            This docstring has nothing in its usage.
+
+            Usage:""",
+            'Failed to parse docstring: "usage:" section is empty.',
+            id="empty_usage_section",
+        ),
+        pytest.param(
+            """\
+            This docstring has only whitespace in its usage.
+
+            Usage:
+
+            Options:""",
+            'Failed to parse docstring: "usage:" section is empty.',
+            id="whitespace_usage_section",
+        ),
     ],
 )
 def test_lint_docstring(doc: str, error_message: str):

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -563,6 +563,35 @@ def test_docopt():
         docopt(doc, "--hel")
 
 
+@pytest.mark.parametrize(
+    "args, before_usage_val", [("", None), ("--before-usage=2", "2")]
+)
+def test_docopt__usage_descriptions_cant_bridge_usage_section(
+    args: str, before_usage_val: str | None
+):
+    # For compatibility with docopt 0.6.2 we support option descriptions
+    # before the usage and after (but not inside usage). However, a
+    # description cannot start in one part and continue in the next.
+    # i.e. the default value after Usage does not apply to
+    # --before-usage
+    usage = """\
+My prog
+
+--before-usage VAL
+
+Usage:
+    prog [options]
+
+[default: 42]
+Options:
+    --after-usage
+"""
+    assert docopt(usage, args) == {
+        "--before-usage": before_usage_val,
+        "--after-usage": False,
+    }
+
+
 def test_language_errors():
     with raises(DocoptLanguageError):
         docopt("no usage with colon here")

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -679,12 +679,13 @@ def test_issue_65_evaluate_argv_when_called_not_when_imported():
 
 
 def test_issue_71_double_dash_is_not_a_valid_option_argument():
-    with raises(DocoptExit):
+    with raises(DocoptExit, match=r"--log requires argument"):
         docopt("usage: prog [--log=LEVEL] [--] <args>...", "--log -- 1 2")
-    with raises(DocoptExit):
+    with raises(DocoptExit, match=r"-l requires argument"):
         docopt(
-            """usage: prog [-l LEVEL] [--] <args>...
-                  options: -l LEVEL""",
+            """\
+usage: prog [-l LEVEL] [--] <args>...
+options: -l LEVEL""",
             "-l -- 1 2",
         )
 

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -886,20 +886,6 @@ def test_parse_docstring_sections(before: str, header: str, body: str, after: st
             """,
             id="no_usage_heading",
         ),
-        pytest.param(
-            """\
-            This doc has a blank line after the usage heading
-
-            Usage:
-
-                myprog [options]
-
-            Options:
-                --foo
-                --bar
-            """,
-            id="blank_line_after_usage_heading",
-        ),
     ],
 )
 def test_parse_docstring_sections__reports_invalid_docstrings(invalid_docstring: str):

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -812,7 +812,12 @@ def test_parse_options(descriptions, options):
     [
         pytest.param("", id="empty"),
         pytest.param("This is a prog\n", id="1line"),
-        pytest.param("This is a prog\n\nInfo:\n Blah blah\n", id="preceding_sections"),
+        pytest.param(
+            "This is a prog\n\nInfo:\n Blah blah\n\n"
+            # contains usage: but not a usage section
+            "Ingredients in pork sausage:\nBlah blah\n",
+            id="preceding_sections",
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -778,6 +778,26 @@ option_examples: Sequence[tuple[str, Sequence[Option]]] = [
             Option(None, "--k", 1, "kval"),
         ],
     ),
+    # Option with description (or other content) on following line.
+    (
+        """
+        Options:
+            -a
+            -b
+         description of b
+            -c
+        Other Options:
+            -d
+        Other Options:-e
+        """,
+        [
+            Option("-a", None, 0, False),
+            Option("-b", None, 0, False),
+            Option("-c", None, 0, False),
+            Option("-d", None, 0, False),
+            Option("-e", None, 0, False),
+        ],
+    ),
 ]
 option_examples = [(dedent(doc), options) for (doc, options) in option_examples]
 

--- a/tests/testcases.docopt
+++ b/tests/testcases.docopt
@@ -950,8 +950,34 @@ local options: --baz
 other options:
  --egg
  --spam
--not-an-option-
-
 """
 $ prog --baz --egg
 {"--foo": false, "--baz": true, "--bar": false, "--egg": true, "--spam": false}
+
+#
+# docopt 0.6.2 compatibility: Blank line in options section
+# https://github.com/jazzband/docopt-ng/issues/33
+#
+r"""Usage: prog [options]
+
+    -h, --help
+    -v, --verbose        be verbose
+
+    -i, --interactive    interactive picking
+    -p, --patch          select hunks interactively
+"""
+$ prog --interactive
+{"--help": false, "--verbose": false, "--interactive": true, "--patch": false}
+
+#
+# docopt 0.6.2 compatibility: Options without leading whitespace
+#
+r"""Usage: prog [options]
+
+--alpha
+-b, --bravo
+-c ARG, --charlie ARG  Something [default: foo]
+"""
+
+$ prog
+{"--alpha": false, "--bravo": false, "--charlie": "foo"}

--- a/tests/testcases.docopt
+++ b/tests/testcases.docopt
@@ -949,10 +949,11 @@ local options: --baz
                --bar
 other options:
  --egg
+ wrapped description of egg.
  --spam
 """
-$ prog --baz --egg
-{"--foo": false, "--baz": true, "--bar": false, "--egg": true, "--spam": false}
+$ prog --baz --spam
+{"--foo": false, "--baz": true, "--bar": false, "--egg": false, "--spam": true}
 
 #
 # docopt 0.6.2 compatibility: Blank line in options section

--- a/tests/testcases.docopt
+++ b/tests/testcases.docopt
@@ -982,3 +982,19 @@ r"""Usage: prog [options]
 
 $ prog
 {"--alpha": false, "--bravo": false, "--charlie": "foo"}
+
+#
+# docopt 0.6.2 compatibility: Options anywhere in doc
+#
+r"""My CLI program
+
+--speed <n>  Is allowed to be defined here in docopt 0.6.2
+             [default: 9000]
+-e, --extra-speed
+
+usage: prog [options]
+options:
+  --direction
+"""
+$ prog --direction -e
+{"--direction": true, "--extra-speed": true, "--speed": "9000"}


### PR DESCRIPTION
This is my proposal to fix #33. (With the assumption that compatibility with docopt is a goal of docopt-ng.)

This PR adds two new functions, `parse_docstring_sections()` and `parse_options()`; and uses them to parse docstrings accepted by docopt 0.6.2, while retaining docopt-ng's improvements to supported syntax.

Currently, docopt-ng parses option-defaults using a strategy that was in docopt's master branch, but considered unstable by the author, and was not released in docopt. It looks for option descriptions in an "options:" section, which is ended on the first blank line. This has the side-effect that options defined in a man-page style — with blank lines in-between — are not found. Neither are options outside an options: section (docopt allows options to follow the usage with no section heading).

parse_docstring_sections() is used to separate the usage section from the rest of the docstring. The text before the usage is ignored. The usage body (without its header) is parsed for the argument pattern and the usage header with its body is used to print the usage summary help. The text following the usage is parsed for options descriptions, using parse_options(), which supports option the description syntax of both docopt and the current docopt-ng.

Note that docopt 0.6.2 recognises option descriptions in the text prior to the usage section, but this change does not, as it seems like an unintended side-effect of the previous parser's implementation, and seems unlikely to be used in practice.

The testcases have two cases added for docopt 0.6.2 compatibility.

The first commit ("Fix test for missing arg before --") could be merged separately, but my final commit's tests depends on it.