### PR TITLE
Assert error message content in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest
+          pytest --cov-report term-missing --cov-report xml --cov=docopt --mypy
 
       - name: Upload coverage
         uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.*
+!.github
+!.gitignore
+!.pre-commit-config.yaml
+
 *.py[co]
 
 # Vim

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -429,7 +429,7 @@ def parse_longer(
     if current_token is None or not current_token.startswith("--"):
         raise tokens.error(
             f"parse_longer got what appears to be an invalid token: {current_token}"
-        )  # pragma: no cover
+        )
     longer, maybe_eq, maybe_value = current_token.partition("=")
     if maybe_eq == maybe_value == "":
         value = None
@@ -463,9 +463,7 @@ def parse_longer(
             print(f"NB: Corrected {corrected[0][0]} to {corrected[0][1].longer}")
         similar = [correct for (original, correct) in corrected]
     if len(similar) > 1:
-        raise tokens.error(
-            f"{longer} is not a unique prefix: {similar}?"
-        )  # pragma: no cover
+        raise tokens.error(f"{longer} is not a unique prefix: {similar}?")
     elif len(similar) < 1:
         argcount = 1 if maybe_eq == "=" else 0
         o = Option(None, longer, argcount)
@@ -497,7 +495,7 @@ def parse_shorts(
     if token is None or not token.startswith("-") or token.startswith("--"):
         raise ValueError(
             f"parse_shorts got what appears to be an invalid token: {token}"
-        )  # pragma: no cover
+        )
     left = token.lstrip("-")
     parsed: list[Pattern] = []
     while left != "":

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -463,7 +463,7 @@ def parse_longer(
             print(f"NB: Corrected {corrected[0][0]} to {corrected[0][1].longer}")
         similar = [correct for (original, correct) in corrected]
     if len(similar) > 1:
-        raise tokens.error(f"{longer} is not a unique prefix: {similar}?")
+        raise DocoptLanguageError(f"{longer} is not a unique prefix: {similar}?")
     elif len(similar) < 1:
         argcount = 1 if maybe_eq == "=" else 0
         o = Option(None, longer, argcount)
@@ -562,8 +562,8 @@ def parse_shorts(
                     de_abbreviated = True
                     break
         if len(similar) > 1:
-            raise tokens.error(
-                "%s is specified ambiguously %d times" % (short, len(similar))
+            raise DocoptLanguageError(
+                f"{short} is specified ambiguously {len(similar)} times"
             )
         elif len(similar) < 1:
             o = Option(short, None, 0)

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -427,7 +427,7 @@ def parse_longer(
     """longer ::= '--' chars [ ( ' ' | '=' ) chars ] ;"""
     current_token = tokens.move()
     if current_token is None or not current_token.startswith("--"):
-        raise tokens.error(
+        raise ValueError(
             f"parse_longer got what appears to be an invalid token: {current_token}"
         )
     longer, maybe_eq, maybe_value = current_token.partition("=")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,4 @@
 requires = ['setuptools', 'wheel']
 
 [tool.pytest.ini_options]
-addopts = "--cov-report term-missing --cov-report xml --cov=docopt --mypy"
-testpaths = [
-    "./tests",
-]
+testpaths = ["./tests"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,4 @@ universal = 1
 [flake8]
 max-line-length = 88
 extend-ignore = E203
+extend-exclude = .*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 import re
+from typing import Generator, Sequence
+from unittest import mock
 
 import docopt
 import pytest
@@ -96,3 +98,20 @@ class DocoptTestItem(pytest.Item):
 
 class DocoptTestException(Exception):
     pass
+
+
+@pytest.fixture(autouse=True)
+def override_sys_argv(argv: Sequence[str]) -> Generator[None, None, None]:
+    """Patch `sys.argv` with a fixed value during tests.
+
+    A lot of docopt tests call docopt() without specifying argv, which uses
+    `sys.argv` by default, so a predictable value for it is necessary.
+    """
+    with mock.patch("sys.argv", new=argv):
+        yield
+
+
+@pytest.fixture
+def argv() -> Sequence[str]:
+    """The `sys.argv` value seen inside tests."""
+    return ["exampleprogram"]

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -467,9 +467,6 @@ def test_parse_longer__rejects_inappropriate_token(tokens: list[str]):
         parse_longer(Tokens(tokens), [])
 
 
-# FIXME: this should raise DocoptLanguage error, not DocoptExit - it's not the
-#   (end) user's fault.
-@pytest.mark.xfail(reason="parse_longer() should raise DocoptLanguageError")
 def test_parse_longer__rejects_duplicate_long_options():
     options = [Option(None, "--foo"), Option(None, "--foo")]
     with raises(DocoptLanguageError, match=r"foo is not a unique prefix"):
@@ -482,6 +479,12 @@ def test_parse_shorts__rejects_inappropriate_token(tokens: list[str]):
         ValueError, match=r"parse_shorts got what appears to be an invalid token"
     ):
         parse_shorts(Tokens(tokens), [])
+
+
+def test_parse_shorts__rejects_duplicate_short_options():
+    options = [Option("-f"), Option("-f")]
+    with raises(DocoptLanguageError, match=r"-f is specified ambiguously 2 times"):
+        parse_shorts(Tokens("-f"), options)
 
 
 def test_long_options_error_handling():

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -19,8 +19,10 @@ from docopt import (
     lint_docstring,
     parse_argv,
     parse_docstring_sections,
+    parse_longer,
     parse_options,
     parse_pattern,
+    parse_shorts,
     formal_usage,
     Tokens,
     transform,
@@ -455,6 +457,32 @@ def test_pattern_fix_identities_2():
     assert pattern.children[0].children[1] is not pattern.children[1]
     pattern.fix_identities()
     assert pattern.children[0].children[1] is pattern.children[1]
+
+
+@pytest.mark.xfail(reason="parse_longer() should raise ValueError (like parse_shorts)")
+@pytest.mark.parametrize("tokens", [[], ["not_a_long_option"]])
+def test_parse_longer__rejects_inappropriate_token(tokens: list[str]):
+    with raises(
+        ValueError, match=r"parse_longer got what appears to be an invalid token"
+    ):
+        parse_longer(Tokens(tokens), [])
+
+
+# FIXME: this should raise DocoptLanguage error, not DocoptExit - it's not the
+#   (end) user's fault.
+@pytest.mark.xfail(reason="parse_longer() should raise DocoptLanguageError")
+def test_parse_longer__rejects_duplicate_long_options():
+    options = [Option(None, "--foo"), Option(None, "--foo")]
+    with raises(DocoptLanguageError, match=r"foo is not a unique prefix"):
+        parse_longer(Tokens("--foo"), options)
+
+
+@pytest.mark.parametrize("tokens", [[], ["not_a_short_option"]])
+def test_parse_shorts__rejects_inappropriate_token(tokens: list[str]):
+    with raises(
+        ValueError, match=r"parse_shorts got what appears to be an invalid token"
+    ):
+        parse_shorts(Tokens(tokens), [])
 
 
 def test_long_options_error_handling():

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -459,7 +459,6 @@ def test_pattern_fix_identities_2():
     assert pattern.children[0].children[1] is pattern.children[1]
 
 
-@pytest.mark.xfail(reason="parse_longer() should raise ValueError (like parse_shorts)")
 @pytest.mark.parametrize("tokens", [[], ["not_a_long_option"]])
 def test_parse_longer__rejects_inappropriate_token(tokens: list[str]):
     with raises(

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -4,6 +4,7 @@ import re
 from textwrap import dedent
 
 from docopt import (
+    ParsedOptions,
     docopt,
     DocoptExit,
     DocoptLanguageError,
@@ -561,6 +562,20 @@ def test_docopt():
 
     with raises(SystemExit):
         docopt(doc, "--hel")
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ({}, "{}"),
+        (
+            {"<z>": None, "<a>": None, "--foo": "abc", "--bar": True},
+            ("{'--bar': True,\n '--foo': 'abc',\n '<a>': None,\n '<z>': None}"),
+        ),
+    ],
+)
+def test_docopt_result_dict_repr(items: dict[str, object], expected: str):
+    assert repr(ParsedOptions(items)) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -1,4 +1,4 @@
-from __future__ import annotations, with_statement
+from __future__ import annotations
 from typing import Sequence
 import re
 from textwrap import dedent

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -684,13 +684,6 @@ def test_issue_40(capsys: pytest.CaptureFixture):
     }
 
 
-def test_issue34_unicode_strings():
-    try:
-        assert docopt(eval("u'usage: prog [-o <a>]'"), "") == {"-o": False, "<a>": None}
-    except SyntaxError:
-        pass  # Python 3
-
-
 def test_count_multiple_flags():
     assert docopt("usage: prog [-v]", "-v") == {"-v": True}
     assert docopt("usage: prog [-vv]", "") == {"-v": 0}

--- a/tests/test_docopt_ng.py
+++ b/tests/test_docopt_ng.py
@@ -153,10 +153,16 @@ def test_docopt_ng_more_magic_global_arguments_and_dot_access():
     }
     assert arguments.FILE is None
 
-    with raises(DocoptExit):
+    with raises(
+        DocoptExit,
+        match=r"Warning: found unmatched \(duplicate\?\) arguments.*output\.py",
+    ):
         docopt.docopt(doc, "-v input.py output.py")
 
-    with raises(DocoptExit):
+    with raises(
+        DocoptExit,
+        match=r"Warning: found unmatched \(duplicate\?\) arguments.*--fake",
+    ):
         docopt.docopt(doc, "--fake")
     arguments = None
 
@@ -180,9 +186,10 @@ def test_docopt_ng_negative_float():
     assert args == {"--negative_pi": "-3.14", "NEGTAU": "-6.28"}
 
 
-def test_docopt_ng_doubledash_version():
+def test_docopt_ng_doubledash_version(capsys: pytest.CaptureFixture):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         docopt.docopt("usage: prog", version=1, argv="prog --version")
+    assert capsys.readouterr().out == "1\n"
     assert pytest_wrapped_e.type == SystemExit
 
 


### PR DESCRIPTION
I'm going to have a crack at making the error messages a little more user-friendly, to resolve #5. Especially the `Warning: found unmatched (duplicate?) arguments [Argument(None, '.\\10. PowerShell.ps1')]` that occurs in response to an end user passing incorrect or too many arguments when running a program using docopt-ng. I need that to be resolved before I can use `docopt-ng` in place of docopt really.

Before making changes there, I'd like to ensure the current messages are tested, so I can be sure I don't change messages unexpectedly. 

This PR mostly adds exception message assertions to all the places where tests trigger an exception or `SystemExit` with usage.

The first 3 commits are unrelated to these messages assertions — small improvements to the dev experience using this repo. They could go into a separate PR if you prefer, but I've already opened a few, so I didn't want to swamp with too many!