### PR TITLE
Add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,8 @@ repos:
     rev: 22.8.0
     hooks:
       - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -23,11 +23,16 @@ Contributors (roughly in chronological order):
 """
 from __future__ import annotations
 
-import sys
-import re
 import inspect
-
-from typing import Any, Callable, NamedTuple, cast, Type, Tuple, Union
+import re
+import sys
+from typing import Any
+from typing import Callable
+from typing import NamedTuple
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
 
 __all__ = ["docopt", "magic_docopt", "magic", "DocoptExit"]
 __version__ = "0.8.1"

--- a/examples/arguments_example.py
+++ b/examples/arguments_example.py
@@ -19,7 +19,6 @@ Options:
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     arguments = docopt(__doc__)
     print(arguments)

--- a/examples/calculator_example.py
+++ b/examples/calculator_example.py
@@ -16,7 +16,6 @@ Options:
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     arguments = docopt(__doc__)
     print(arguments)

--- a/examples/counted_example.py
+++ b/examples/counted_example.py
@@ -12,5 +12,4 @@ Try: counted_example.py -vvvvvvvvvv
 """
 from docopt import docopt
 
-
 print(docopt(__doc__))

--- a/examples/git/git.py
+++ b/examples/git/git.py
@@ -27,7 +27,6 @@ from subprocess import call
 
 from docopt import docopt
 
-
 if __name__ == "__main__":
 
     args = docopt(__doc__, version="git version 1.7.4.4", options_first=True)

--- a/examples/git/git_add.py
+++ b/examples/git/git_add.py
@@ -18,6 +18,5 @@
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     print(docopt(__doc__))

--- a/examples/git/git_branch.py
+++ b/examples/git/git_branch.py
@@ -28,6 +28,5 @@ Specific git-branch actions:
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     print(docopt(__doc__))

--- a/examples/git/git_checkout.py
+++ b/examples/git/git_checkout.py
@@ -18,6 +18,5 @@
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     print(docopt(__doc__))

--- a/examples/git/git_clone.py
+++ b/examples/git/git_clone.py
@@ -25,6 +25,5 @@
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     print(docopt(__doc__))

--- a/examples/git/git_commit.py
+++ b/examples/git/git_commit.py
@@ -45,6 +45,5 @@ Commit contents options
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     print(docopt(__doc__))

--- a/examples/git/git_push.py
+++ b/examples/git/git_push.py
@@ -22,6 +22,5 @@
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     print(docopt(__doc__))

--- a/examples/git/git_remote.py
+++ b/examples/git/git_remote.py
@@ -17,7 +17,6 @@ usage: git remote [-v | --verbose]
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     arguments = docopt(__doc__)
     print(arguments)

--- a/examples/interactive_example.py
+++ b/examples/interactive_example.py
@@ -15,9 +15,11 @@ Options:
     --baud=<n>  Baudrate [default: 9600]
 """
 
-import sys
 import cmd
-from docopt import docopt, DocoptExit
+import sys
+
+from docopt import DocoptExit
+from docopt import docopt
 
 
 def docopt_cmd(func):

--- a/examples/naval_fate.py
+++ b/examples/naval_fate.py
@@ -18,7 +18,6 @@ Options:
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     arguments = docopt(__doc__, version="Naval Fate 2.0")
     print(arguments)

--- a/examples/odd_even_example.py
+++ b/examples/odd_even_example.py
@@ -9,7 +9,6 @@ Options:
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     arguments = docopt(__doc__)
     print(arguments)

--- a/examples/options_example.py
+++ b/examples/options_example.py
@@ -33,7 +33,6 @@ Options:
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     arguments = docopt(__doc__, version="1.0.0rc2")
     print(arguments)

--- a/examples/options_shortcut_example.py
+++ b/examples/options_shortcut_example.py
@@ -14,7 +14,6 @@ Options:
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     arguments = docopt(__doc__, version="1.0.0rc2")
     print(arguments)

--- a/examples/quick_example.py
+++ b/examples/quick_example.py
@@ -6,7 +6,6 @@
 """
 from docopt import docopt
 
-
 if __name__ == "__main__":
     arguments = docopt(__doc__, version="0.1.1rc")
     print(arguments)

--- a/examples/validation_example.py
+++ b/examples/validation_example.py
@@ -13,7 +13,11 @@ import os
 from docopt import docopt
 
 try:
-    from schema import Schema, And, Or, Use, SchemaError
+    from schema import And
+    from schema import Or
+    from schema import Schema
+    from schema import SchemaError
+    from schema import Use
 except ImportError:
     exit(
         "This example requires that `schema` data-validation library"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,8 @@ requires = ['setuptools', 'wheel']
 
 [tool.pytest.ini_options]
 testpaths = ["./tests"]
+
+[tool.isort]
+profile = "black"
+# Place each import on its own line to reduce merge conflicts
+force_single_line = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ dev =
     black
     build
     flake8
+    isort
     mypy
     pre-commit
     pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 import json
-from pathlib import Path
 import re
-from typing import Generator, Sequence
+from pathlib import Path
+from typing import Generator
+from typing import Sequence
 from unittest import mock
 
-import docopt
 import pytest
+
+import docopt
 
 
 def pytest_collect_file(file_path: Path, path, parent):

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -1,34 +1,34 @@
 from __future__ import annotations
-from typing import Sequence
+
 import re
 from textwrap import dedent
+from typing import Sequence
 
-from docopt import (
-    ParsedOptions,
-    docopt,
-    DocoptExit,
-    DocoptLanguageError,
-    Option,
-    Argument,
-    Command,
-    OptionsShortcut,
-    Required,
-    NotRequired,
-    Either,
-    OneOrMore,
-    lint_docstring,
-    parse_argv,
-    parse_docstring_sections,
-    parse_longer,
-    parse_options,
-    parse_pattern,
-    parse_shorts,
-    formal_usage,
-    Tokens,
-    transform,
-)
 import pytest
 from pytest import raises
+
+from docopt import Argument
+from docopt import Command
+from docopt import DocoptExit
+from docopt import DocoptLanguageError
+from docopt import Either
+from docopt import NotRequired
+from docopt import OneOrMore
+from docopt import Option
+from docopt import OptionsShortcut
+from docopt import ParsedOptions
+from docopt import Required
+from docopt import Tokens
+from docopt import docopt
+from docopt import formal_usage
+from docopt import lint_docstring
+from docopt import parse_argv
+from docopt import parse_docstring_sections
+from docopt import parse_longer
+from docopt import parse_options
+from docopt import parse_pattern
+from docopt import parse_shorts
+from docopt import transform
 
 
 def test_pattern_flat():

--- a/tests/test_docopt_ng.py
+++ b/tests/test_docopt_ng.py
@@ -1,10 +1,16 @@
 import pytest
-import docopt
-from docopt import DocoptExit, DocoptLanguageError, Option, Argument, parse_argv, Tokens
 from pytest import raises
+
+import docopt
+from docopt import Argument
+from docopt import DocoptExit
+from docopt import DocoptLanguageError
+from docopt import Option
+from docopt import Tokens
+from docopt import docopt as user_provided_alias_containing_magic
 from docopt import magic
 from docopt import magic_docopt
-from docopt import docopt as user_provided_alias_containing_magic
+from docopt import parse_argv
 
 
 def test_docopt_ng_more_magic_spellcheck_and_expansion():


### PR DESCRIPTION
closes #39

I configured isort in pyproject.toml, not setup.cfg,
because ideally we migrate to just having that file
in the future.