### PR TITLE
Allows quoted default values

### DIFF
--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -323,10 +323,11 @@ class Option(LeafPattern):
             matched = re.findall(r"\[default: (.*)\]", description, flags=re.I)
             if matched:
                 value = matched[0]
-                if value.startswith("'") and value.endswith("'"):
-                    value = value[1:-1]
-                elif value.startswith('"') and value.endswith('"'):
-                    value = value[1:-1]
+                if len(value) > 1:
+                    if value.startswith("'") and value.endswith("'"):
+                        value = value[1:-1]
+                    elif value.startswith('"') and value.endswith('"'):
+                        value = value[1:-1]
             else:
                 value = None
         return class_(short, longer, argcount, value)

--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -321,7 +321,14 @@ class Option(LeafPattern):
                 argcount = 1
         if argcount:
             matched = re.findall(r"\[default: (.*)\]", description, flags=re.I)
-            value = matched[0] if matched else None
+            if matched:
+                value = matched[0]
+                if value.startswith("'") and value.endswith("'"):
+                    value = value[1:-1]
+                elif value.startswith('"') and value.endswith('"'):
+                    value = value[1:-1]
+            else:
+                value = None
         return class_(short, longer, argcount, value)
 
     def single_match(self, left: list[LeafPattern]) -> TSingleMatch:


### PR DESCRIPTION
As mentioned in #46 there is a use cases for quoting default value (when having spaces in the default value). This PR allows such single/double quoted default value.

For your consideration.