### PR TITLE
This reworks the transform function somewhat to speed it up.

### DIFF
--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -125,8 +125,8 @@ class _Pattern:
         return self._name
 
     def __eq__(self, other) -> bool:
-        if not isinstance(other, _Pattern):
-            return NotImplemented
+        if type(self) != type(other):
+            return False
         return self._repr == other._repr
 
     def __hash__(self) -> int:


### PR DESCRIPTION
This takes the time taken for the ls example from 2.6s to 0.5s on my PC.

The problem mostly seems to be related to the __eq__ function using repr, so I've cached the __repr__ value . I've also rearranged the transform function a little to avoid it finding out if there were any matching children and then getting the first child in the list.

Found one small tweak to improve it but I think this as good as it'll get without a rewrite

Fixes #16