### PR TITLE
Fix PytestRemovedIn9Warning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 import docopt
 
 
-def pytest_collect_file(file_path: Path, path, parent):
+def pytest_collect_file(file_path: Path, parent):
     if file_path.suffix == ".docopt" and file_path.stem.startswith("test"):
         return DocoptTestFile.from_parent(path=file_path, parent=parent)
 


### PR DESCRIPTION
Thank you so much for giving this important package a renewed life and taking into its maintenance!

Just recently tried to run some tests while migrating to python3.12 and found that all test passed but show an strange PytestRemovedIn9Warning for a deprecated 'path' argument that is easily solved with:

```
-def pytest_collect_file(file_path: Path, path, parent):
+def pytest_collect_file(file_path: Path, parent):
```

Turns out Pytest is in the process of updating that function as documented in https://docs.pytest.org/en/8.2.x/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path and https://docs.pytest.org/en/8.2.x/reference/reference.html#std-hook-pytest_collect_file

I'm actively using docopt-ng and thought was a good opportunity to give back.
