### PR TITLE
Fix repeated option values across usage alternatives

### DIFF
--- a/docopt/__init__.py
+++ b/docopt/__init__.py
@@ -314,7 +314,14 @@ class _Option(_LeafPattern):
     def single_match(self, left: list[_LeafPattern]) -> _SingleMatch:
         for n, pattern in enumerate(left):
             if self.name == pattern.name:
-                return n, pattern
+                value = (
+                    pattern.value.copy()
+                    if isinstance(pattern.value, list)
+                    else pattern.value
+                )
+                return n, _Option(
+                    pattern.short, pattern.longer, pattern.argcount, value
+                )
         return None, None
 
     @property

--- a/tests/test_docopt.py
+++ b/tests/test_docopt.py
@@ -765,6 +765,25 @@ def test_issue_40(capsys: pytest.CaptureFixture):
     }
 
 
+def test_issue_60_repeated_options_across_usage_alternatives():
+    doc = """
+    Usage:
+        test.py [--to=SITE]... [--] FILE...
+        test.py [--to=SITE]... --config CONFIG [[--] FILE...]
+
+    Options:
+        --config CONFIG     Configuration file.
+        --to=SITE           Target site
+    """
+
+    assert docopt(doc, "--to a --to b c") == {
+        "--": False,
+        "--config": None,
+        "--to": ["a", "b"],
+        "FILE": ["c"],
+    }
+
+
 def test_count_multiple_flags():
     assert docopt("usage: prog [-v]", "-v") == {"-v": True}
     assert docopt("usage: prog [-vv]", "") == {"-v": 0}


### PR DESCRIPTION
Closes #60.

This fixes the repeated-option case from the issue where matching one usage alternative could mutate the parsed option object shared with another alternative. `_Option.single_match()` now returns a fresh option object for the match, so a failed branch attempt cannot leak value changes back into the shared argv token list.

Validation:
- `uv run --no-project --with pytest python -m pytest tests/test_docopt.py::test_issue_60_repeated_options_across_usage_alternatives tests/test_docopt.py::test_count_multiple_flags -q`
- `uv run --no-project --with pytest python -m pytest -q`
- `uv run --no-project --with ruff ruff check docopt/__init__.py tests/test_docopt.py`
- `git diff --check HEAD~1..HEAD`
- `review-fix-loop` clean
